### PR TITLE
Add tests for IMEI and Excel parsing helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# giderpusulasi
+
+## Testing
+
+This project uses [pytest](https://pytest.org) for unit tests.
+Run the tests with:
+
+```bash
+pytest -q
+```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -q
+pythonpath = .

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+import sys
+import types
+
+# Stub modules imported by arama23 but absent in the test environment.
+modules = {
+    "requests": types.ModuleType("requests"),
+    "requests.adapters": types.ModuleType("requests.adapters"),
+    "urllib3": types.ModuleType("urllib3"),
+    "urllib3.util": types.ModuleType("urllib3.util"),
+    "urllib3.util.retry": types.ModuleType("urllib3.util.retry"),
+    "openpyxl": types.ModuleType("openpyxl"),
+    "openpyxl.utils": types.ModuleType("openpyxl.utils"),
+    "tkinter": types.ModuleType("tkinter"),
+    "tkinter.ttk": types.ModuleType("tkinter.ttk"),
+    "tkinter.filedialog": types.ModuleType("tkinter.filedialog"),
+    "tkinter.messagebox": types.ModuleType("tkinter.messagebox"),
+    "tkinter.scrolledtext": types.ModuleType("tkinter.scrolledtext"),
+}
+
+# minimal stand-ins for used classes/functions
+modules["requests"].Session = object
+modules["requests.adapters"].HTTPAdapter = object
+modules["urllib3.util.retry"].Retry = object
+modules["tkinter"].Tk = object
+
+openpyxl = modules["openpyxl"]
+class Workbook:  # pragma: no cover - simple stub
+    pass
+
+def load_workbook(*args, **kwargs):  # pragma: no cover - simple stub
+    return Workbook()
+openpyxl.Workbook = Workbook
+openpyxl.load_workbook = load_workbook
+
+utils = modules["openpyxl.utils"]
+def get_column_letter(i):  # pragma: no cover - simple stub
+    return str(i)
+utils.get_column_letter = get_column_letter
+
+for name, module in modules.items():
+    sys.modules.setdefault(name, module)

--- a/tests/test_excel.py
+++ b/tests/test_excel.py
@@ -1,0 +1,77 @@
+from arama23 import _build_header_map, parse_gp_template_workbook, HEADERS
+
+
+class FakeCell:
+    def __init__(self, value):
+        self.value = value
+
+
+class FakeWorksheet:
+    def __init__(self, rows, title="Sheet1"):
+        self._rows = rows
+        self.title = title
+        self.max_row = len(rows)
+        self.max_column = max(len(r) for r in rows)
+
+    def cell(self, row, column):
+        try:
+            return FakeCell(self._rows[row - 1][column - 1])
+        except IndexError:
+            return FakeCell(None)
+
+
+class FakeWorkbook:
+    def __init__(self, worksheets):
+        self.worksheets = worksheets
+
+
+def test_build_header_map_detects_headers():
+    rows = [
+        ["IMEI", "Belge Türü", "MODEL", "SATIŞ TARİHi", "ALICI ADI SOYADI"],
+        [None, None, None, None, None],
+    ]
+    ws = FakeWorksheet(rows)
+    hm = _build_header_map(ws)
+    assert hm == {
+        "row": 1,
+        "cols": {
+            0: "imei",
+            1: "Belge Türü",
+            2: "MODEL",
+            3: "SATIŞ TARİHi",
+            4: "ALICI ADI SOYADI",
+        },
+    }
+
+
+def test_parse_gp_template_workbook_extracts_rows():
+    rows = [
+        ["IMEI", "Belge Türü", "MODEL", "SATIŞ TARİHi", "ALICI ADI SOYADI"],
+        ["490154203237518", "GIDER PUSULASI", "iPhone 11", "2024-01-01", "Alice"],
+        ["invalid", "", "IMEI: 352099001761481", "", ""],
+    ]
+    ws = FakeWorksheet(rows)
+    wb = FakeWorkbook([ws])
+    logs = []
+    out = parse_gp_template_workbook(wb, logs.append)
+
+    assert logs == ["[GP] Sayfa 'Sheet1': 2 satır alındı."]
+    assert len(out) == 2
+
+    i_imei = HEADERS.index("imei")
+    i_brand = HEADERS.index("Marka")
+    i_status = HEADERS.index("DURUMU")
+    i_loc = HEADERS.index("Bulunma")
+    i_doc_type = HEADERS.index("ALIŞ BELGELERİ TÜRÜ")
+
+    row1, row2 = out
+    assert row1[i_imei] == "490154203237518"
+    assert row1[i_brand] == "APPLE"
+    assert row1[i_status] == "Satılmış"
+    assert row1[i_loc] == "GP"
+    assert row1[i_doc_type] == "Gider Pusulası"
+
+    assert row2[i_imei] == "352099001761481"
+    assert row2[i_brand] == "Bilinmeyen"
+    assert row2[i_status] == "Satılabilir"
+    assert row2[i_loc] == "GP"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,29 @@
+import pytest
+from arama23 import extract_imeis, _luhn_ok_imei, brand_from_text
+
+
+@pytest.mark.parametrize('imei,expected', [
+    ("490154203237518", True),
+    ("490154203237517", False),
+    ("12345", False),
+])
+def test_luhn_ok_imei(imei, expected):
+    assert _luhn_ok_imei(imei) is expected
+
+
+def test_extract_imeis_deduplicates_and_validates():
+    text = (
+        "IMEI 490154203237518 and 352099001761481 "
+        "and invalid 123456789012345 and again 490154203237518"
+    )
+    assert extract_imeis(text) == ["352099001761481", "490154203237518"]
+
+
+@pytest.mark.parametrize('text,brand', [
+    ("My new iPhone 11 is great", "APPLE"),
+    ("Samsung Galaxy S22", "SAMSUNG"),
+    ("Huawei Honor Magic", "HONOR"),
+    ("Unknown device", "Bilinmeyen"),
+])
+def test_brand_from_text(text, brand):
+    assert brand_from_text(text) == brand


### PR DESCRIPTION
## Summary
- add unit tests for IMEI helpers and brand detection
- cover Excel header mapping and workbook parsing with stub workbook objects
- configure pytest and document how to run tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb59451e388332a8e6d2495d5a44b4